### PR TITLE
DNS client implementation

### DIFF
--- a/11_dns/dns.c
+++ b/11_dns/dns.c
@@ -28,8 +28,9 @@ typedef struct dns_hdr_s {
 
 typedef struct dns_qtn_s {
   char * name;
-  uint16_t len;
-  uint16_t class;  
+  uint8_t len;
+  uint16_t class;
+  uint16_t type;
 } dns_qtn_t;
 
 typedef struct dns_msg_s {
@@ -49,7 +50,7 @@ uint16_t read_short(char * buff) {
 }
 
 // encode dns header for transmission (struct -> buffer)
-void encode_dns_head(dns_hdr_t * head, char * buff, short len) {
+void encode_dns_head(dns_hdr_t * hdr, char * buff, short len) {
   // assume that buff is already initialised with sufficient length
 
   // id
@@ -84,7 +85,23 @@ void encode_dns_head(dns_hdr_t * head, char * buff, short len) {
 }
 
 // encode dns question for transmission (struct -> buffer)
-void encode_dns_qtn(dns_qtn_t * qtn, char * buff, short len);
+void encode_dns_qtn(dns_qtn_t * qtn, char * buff, short len) {
+  // assume that buff has sufficient length to contain question struct
+
+  *(buff) = qtn->len;
+
+  // inject request string into buff one char at a time
+  for (int i = 0; i < qtn->len; i++) {
+    *(buff + i) = qtn->name[i];
+  }
+
+  *(buff + qtn->len + 1) = (unsigned char) (qtn->type & 0xFF00) >> 8;
+  *(buff + qtn->len + 2) = (unsigned char) qtn->type & 0x00FF;
+  
+  *(buff + qtn->len + 3) = (unsigned char) (qtn->class & 0xFF00) >> 8;
+  *(buff + qtn->len + 4) = (unsigned char) qtn->class & 0x00FF;
+  
+}
 
 // encode dns message for transmission (struct -> buffer)
 void encode_dns_msg(dns_msg_t * msg, char * buff, short len);

--- a/11_dns/dns.c
+++ b/11_dns/dns.c
@@ -52,6 +52,35 @@ uint16_t read_short(char * buff) {
 void encode_dns_head(dns_hdr_t * head, char * buff, short len) {
   // assume that buff is already initialised with sufficient length
 
+  // id
+  *(buff) = hdr->id;
+
+  // flags - first octet: QR + OPTCODE + AA + TC + RD
+  *(buff + 2) =
+    (hdr->flags.qr << 7) |
+    (hdr->flags.optcode << 3) |
+    (hdr->flags.aa << 2) |
+    (hdr->flags.tc << 1) |
+    (hdr->flags.rd);
+
+  // flags - second octet
+  *(buff + 3) =
+    (hdr->flags.ra << 7) |
+    (hdr->flags.z << 4) |
+    (hdr->flags.rcode);
+
+  // qdcount
+  *(buff + 4) = hdr->qdcount;
+
+  // ancount
+  *(buff + 6) = hdr->ancount;
+
+  // nscount
+  *(buff + 8) = hdr->nscount;
+
+  // arcount
+  *(buff + 10) = hdr->arcount;
+
 }
 
 // encode dns question for transmission (struct -> buffer)

--- a/11_dns/dns.c
+++ b/11_dns/dns.c
@@ -50,13 +50,15 @@ uint16_t read_short(char * buff) {
 }
 
 // encode dns header for transmission (struct -> buffer)
-void encode_dns_head(dns_hdr_t * hdr, char * buff, short len) {
+void encode_dns_head(dns_hdr_t * hdr, char * buff, short len)
+{
   // assume that buff is already initialised with sufficient length
 
   // id
-  *(buff) = hdr->id;
+  *(buff) = (unsigned char) (hdr->id && 0xFF00) >> 8;
+  *(buff + 1) = (unsigned char) (hdr->id && 0x00FF);
 
-  // flags - first octet: QR + OPTCODE + AA + TC + RD
+  // flags - first octet: QR + OPCODE + AA + TC + RD
   *(buff + 2) =
     (hdr->flags.qr << 7) |
     (hdr->flags.optcode << 3) |
@@ -71,21 +73,26 @@ void encode_dns_head(dns_hdr_t * hdr, char * buff, short len) {
     (hdr->flags.rcode);
 
   // qdcount
-  *(buff + 4) = hdr->qdcount;
+  *(buff + 4) = (unsigned char) (hdr->qdcount && 0xFF00) >> 8;
+  *(buff + 5) = (unsigned char) (hdr->qdcount && 0x00FF);
 
   // ancount
-  *(buff + 6) = hdr->ancount;
+  *(buff + 6) = (unsigned char) (hdr->ancount && 0xFF00) >> 8;
+  *(buff + 7) = (unsigned char) (hdr->ancount && 0x00FF);
 
   // nscount
-  *(buff + 8) = hdr->nscount;
+  *(buff + 8) = (unsigned char) (hdr->nscount && 0xFF00) >> 8;
+  *(buff + 9) = (unsigned char) (hdr->ancount && 0x00FF);
 
   // arcount
-  *(buff + 10) = hdr->arcount;
+  *(buff + 10) = (unsigned char) (hdr->arcount && 0xFF00) >> 8;
+  *(buff + 11) = (unsigned char) (hdr->ancount && 0x00FF);
 
 }
 
 // encode dns question for transmission (struct -> buffer)
-void encode_dns_qtn(dns_qtn_t * qtn, char * buff, short len) {
+void encode_dns_qtn(dns_qtn_t * qtn, char * buff)
+{
   // assume that buff has sufficient length to contain question struct
 
   *(buff) = qtn->len;
@@ -104,7 +111,10 @@ void encode_dns_qtn(dns_qtn_t * qtn, char * buff, short len) {
 }
 
 // encode dns message for transmission (struct -> buffer)
-void encode_dns_msg(dns_msg_t * msg, char * buff, short len);
+void encode_dns_msg(dns_msg_t * msg, char * buff)
+{
+  
+}
 
 // decode received dns header (buffer -> struct)
 void decode_dns_head(char * buff, short len, dns_hdr_t * hdr)

--- a/11_dns/dns.c
+++ b/11_dns/dns.c
@@ -1,6 +1,64 @@
 #include <stdio.h>
 
+#include <sys/socket.h>
+
+#include <stdint.h>
+
+typedef struct dns_head_s {
+  uint16_t id;
+  uint16_t flags;
+  uint16_t qdcount;
+  uint16_t ancount;
+  uint16_t nscount;
+  uint16_t arcount;
+} dns_head_t;
+
+typedef struct dns_qtn_s {
+  char * name;
+  uint16_t len;
+  uint16_t class;  
+} dns_qtn_t;
+
+typedef struct dns_msg_s {
+  char * name;
+  uint16_t type;
+  uint16_t class;
+  uint16_t ttl;
+  uint16_t rdlength;
+  char * rdata;
+} dns_msg_t;
+
+void encode_dns_head(dns_head_t * head, char * buff, short len) {
+  // assume that buff is already initialised with sufficient length
+
+  
+}
+
+void encode_dns_qtn(dns_qtn_t * qtn, char * buff, short len);
+void encode_dns_msg(dns_msg_t * msg, char * buff, short len);
+
 int main()
 {
-  printf("hi\n");
+  int sockfd = socket(AF_INET, SOCK_DGRAM, 0);
+
+  struct sockaddr * bind_addr;
+  int b = bind(sockfd, bind_addr, sizeof(bind_addr));
+
+  // information to send
+
+  char * domain = "bradfieldcs.com";
+
+  short DNS_HEAD_SIZE = 12; // in bytes
+  // construct header
+  char * header[DNS_HEAD_SIZE + 1];
+  short arcount = 0;
+  short nscount = 0;
+  short ancount = 0;
+  short qdcount = 1;
+  short flags = 0;
+  header[DNS_HEAD_SIZE] = 0;
+
+  // construct question
+
+  // construct answer
 }

--- a/11_dns/dns.c
+++ b/11_dns/dns.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main()
+{
+  printf("hi\n");
+}

--- a/11_dns/dns.c
+++ b/11_dns/dns.c
@@ -17,14 +17,14 @@ typedef struct dns_hdr_flags_s {
   uint16_t rcode : 4;
 } dns_hdr_flags_t;
 
-typedef struct dns_head_s {
+typedef struct dns_hdr_s {
   uint16_t id;
   dns_hdr_flags_t flags;
   uint16_t qdcount;
   uint16_t ancount;
   uint16_t nscount;
   uint16_t arcount;
-} dns_head_t;
+} dns_hdr_t;
 
 typedef struct dns_qtn_s {
   char * name;
@@ -48,32 +48,40 @@ uint16_t read_short(char * buff) {
   return *(buff) << 8 | *(buff + 1);
 }
 
-void encode_dns_head(dns_head_t * head, char * buff, short len) {
+// encode dns header for transmission (struct -> buffer)
+void encode_dns_head(dns_hdr_t * head, char * buff, short len) {
   // assume that buff is already initialised with sufficient length
 
-  head->id = read_short(&buff[0]);
-
-  // get flags
-  head->flags.qr = (buff[2] >> 7) & 0x1;
-  head->flags.optcode = (buff[2] >> 4) & 0xF;
-  head->flags.aa = (buff[2] >> 2) & 0x1;
-  head->flags.tc = (buff[2] >> 1) & 0x1;
-  head->flags.rd = (buff[2]) & 0x1;
-  head->flags.ra = (buff[3] >> 7) & 0x1;
-  head->flags.z = (buff[3] >> 4) & 0x7;
-  head->flags.rcode = (buff[3]) & 0xF;
-  
-  head->qdcount = read_short(&buff[4]);
-  head->ancount = read_short(&buff[6]);
-  head->nscount = read_short(&buff[8]);
-  head->arcount = read_short(&buff[10]);
-  
 }
 
+// encode dns question for transmission (struct -> buffer)
 void encode_dns_qtn(dns_qtn_t * qtn, char * buff, short len);
+
+// encode dns message for transmission (struct -> buffer)
 void encode_dns_msg(dns_msg_t * msg, char * buff, short len);
 
-void decode_dns_head(char * buff, short len, dns_msg_t * qtn);
+// decode received dns header (buffer -> struct)
+void decode_dns_head(char * buff, short len, dns_hdr_t * hdr)
+{
+  hdr->id = read_short(&buff[0]);
+
+  // get flags
+  hdr->flags.qr = (buff[2] >> 7) & 0x1;
+  hdr->flags.optcode = (buff[2] >> 4) & 0xF;
+  hdr->flags.aa = (buff[2] >> 2) & 0x1;
+  hdr->flags.tc = (buff[2] >> 1) & 0x1;
+  hdr->flags.rd = (buff[2]) & 0x1;
+  hdr->flags.ra = (buff[3] >> 7) & 0x1;
+  hdr->flags.z = (buff[3] >> 4) & 0x7;
+  hdr->flags.rcode = (buff[3]) & 0xF;
+  
+  hdr->qdcount = read_short(&buff[4]);
+  hdr->ancount = read_short(&buff[6]);
+  hdr->nscount = read_short(&buff[8]);
+  hdr->arcount = read_short(&buff[10]);
+}
+
+// decode received dns message (buffer -> struct)
 void decode_dns_msg(char * buff, short len, dns_msg_t * msg);
 
 int main()


### PR DESCRIPTION
# Objective
Implement a command line DNS client that should be able to retrieve DNS records for a given domain name. The tool should use Google's DNS sever at `8.8.8.8` and should be possible to specify the type of records to retrieve - A, NS, * (default).

# Progress

- define structs to contain DNS header, question and message bistreams
- define functions to encode/decode structs to and from a character array [in progress]

# Remainder

- parse command line arguments to specify domain name and record types for request
- construct request address struct pointing at Google's DNS server
- dispatch UDP request 
- parse/validate UDP response
- unpack DNS message from UDP 
- print result/errors 