### PR TITLE
Parse PCAP network capture file

### DIFF
--- a/10_networking_overview/makefile
+++ b/10_networking_overview/makefile
@@ -1,0 +1,2 @@
+all:
+	cc `pkg-config --cflags glib-2.0` parse.c -o parse && ./parse

--- a/10_networking_overview/parse.c
+++ b/10_networking_overview/parse.c
@@ -38,23 +38,24 @@ gint32 get_long_signed(char * buff) {
 
 int main ()
 {
+  short HEAD_SIZE = 24;
   pcap_hdr_t head;
 
   FILE * f = fopen("net.cap", "r");
 
-  unsigned char stuff[24];
-  fgets(stuff, 24, f);
+  unsigned char stuff[HEAD_SIZE + 1];
+  fgets(stuff, HEAD_SIZE+1, f);
 
   // head = (pcap_hdr_t) *stuff;
 
-  printf("-- header bytes start --\n");
-  for (int i = 0; i < 24; i++) {
-     printf("0x%02X\n", stuff[i]);
-    /* unsigned char c = getc(f); */
-    /* stuff[0] = c; */
-    /* printf("0x%02X\n", c); */
-  }
-  printf("-- header bytes end --\n");
+  /* printf("-- header bytes start --\n"); */
+  /* for (int i = 0; i < 24; i++) { */
+  /*    printf("0x%02X\n", stuff[i]); */
+  /*   /\* unsigned char c = getc(f); *\/ */
+  /*   /\* stuff[0] = c; *\/ */
+  /*   /\* printf("0x%02X\n", c); *\/ */
+  /* } */
+  /* printf("-- header bytes end --\n"); */
 
   printf("magic: 0x%08X\n", get_long(&stuff[0]));
   printf("vers (maj): 0x%04X\n", get_short(&stuff[4])); 
@@ -67,14 +68,23 @@ int main ()
   // start a cycle of reading header + packet until EOF
   while (1) {
     short HEADSIZE = 128;
-    unsigned char headbytes[HEADSIZE];
-    fgets(headbytes, HEADSIZE, f);
+    unsigned char headbytes[HEADSIZE + 1]; // array needs and extra char at end for NUL
+    fgets(headbytes, HEADSIZE+1, f); // fgets reads up to N - 1 chars to make space for NUL at end
+
+    printf("0x%X\n", headbytes[HEADSIZE]);
+    for (int i = 0; i < HEADSIZE; i++) {
+      printf("head c = %02x\n", headbytes[i]);
+
+      if (i > 10) break;
+    }
+    
 
     time_t tim = get_long(headbytes);
     // time_t now = time(&now);
     // struct tm * loc_tm = localtime(&now);
     // printf("%lu\n", time);
-    printf("ts_sec: %s\n", asctime(localtime(&tim)));
+    printf("ts time: %s\n", asctime(localtime(&tim)));
+    printf("ts_sec: %X\n", get_long(headbytes));
     printf("ts_usec: %lu\n", get_long(headbytes + 4));
     printf("incl_len: %lu\n", get_long(headbytes + 8));
     printf("orig_len: %lu\n", get_long(headbytes + 12));

--- a/10_networking_overview/parse.c
+++ b/10_networking_overview/parse.c
@@ -1,0 +1,83 @@
+#include <stdio.h>
+
+#include <time.h> 
+#include <glib.h>
+#include <arpa/inet.h>
+
+typedef struct pcap_hdr_s {
+  guint32 magic_number;   /* magic number */
+  guint16 version_major;  /* major version number */
+  guint16 version_minor;  /* minor version number */
+  gint32  thiszone;       /* GMT to local correction */
+  guint32 sigfigs;        /* accuracy of timestamps */
+  guint32 snaplen;        /* max length of captured packets, in octets */
+  guint32 network;        /* data link type */  
+} pcap_hdr_t;
+
+// reads 16 bits in little endian format
+guint16 get_short (char * buff)
+{
+  return buff[1] << 8 | buff[0];
+}
+
+// reads 32 bits in little endian format
+guint32 get_long (char * buff)
+{
+  return
+    (unsigned char) *(buff) |
+    (unsigned char) *(buff+1) << 8 |
+    (unsigned char) *(buff+2) << 8 * 2 |
+    (unsigned char) *(buff+3) << 8 * 3;
+}
+
+// reads 32 bits and returns them as a signed value
+// TODO: fix implementation of this
+gint32 get_long_signed(char * buff) {
+  return (gint32) get_long(buff);
+}
+
+int main ()
+{
+  pcap_hdr_t head;
+
+  FILE * f = fopen("net.cap", "r");
+
+  unsigned char stuff[24];
+  fgets(stuff, 24, f);
+
+  // head = (pcap_hdr_t) *stuff;
+
+  printf("-- header bytes start --\n");
+  for (int i = 0; i < 24; i++) {
+     printf("0x%02X\n", stuff[i]);
+    /* unsigned char c = getc(f); */
+    /* stuff[0] = c; */
+    /* printf("0x%02X\n", c); */
+  }
+  printf("-- header bytes end --\n");
+
+  printf("magic: 0x%08X\n", get_long(&stuff[0]));
+  printf("vers (maj): 0x%04X\n", get_short(&stuff[4])); 
+  printf("vers (min): 0x%04X\n", get_short(&stuff[6]));
+  printf("zone: %lu\n", get_long(&stuff[8]));
+  printf("sigfig: %lu\n", get_long(&stuff[12]));
+  printf("len: %lu\n", get_long(&stuff[16]));
+  printf("net: %lu\n", get_long(&stuff[20])); // 1 for ethernet
+
+  // start a cycle of reading header + packet until EOF
+  while (1) {
+    short HEADSIZE = 128;
+    unsigned char headbytes[HEADSIZE];
+    fgets(headbytes, HEADSIZE, f);
+
+    time_t tim = get_long(headbytes);
+    // time_t now = time(&now);
+    // struct tm * loc_tm = localtime(&now);
+    // printf("%lu\n", time);
+    printf("ts_sec: %s\n", asctime(localtime(&tim)));
+    printf("ts_usec: %lu\n", get_long(headbytes + 4));
+    printf("incl_len: %lu\n", get_long(headbytes + 8));
+    printf("orig_len: %lu\n", get_long(headbytes + 12));
+    break;
+  }
+}

--- a/10_networking_overview/parse.c
+++ b/10_networking_overview/parse.c
@@ -139,13 +139,47 @@ int main ()
     // fgets(data, PAYLOADSIZE+1, f);
     // char c;
     for (int i = 0; i < PAYLOADSIZE; i++) {
-      c = getc(f); 
-      // printf("%d, %d, %02X\n", PAYLOADSIZE, i, getc(f));
+      //c = getc(f);
+      data[i] = getc(f);
+      // printf("%d, %d, %02X\n", PAYLOADSIZE, i, data[i]);
     }
+    data[PAYLOADSIZE + 1] = 0; // append NUL
 
     // checks if EOF was encountered after reading payload
     if (feof(f))
       break;
+
+    // ---- parse ETH packet
+    short ETH_HEAD_SIZE = 14;
+ 
+    /**
+     * data values 0 - 5 encode source MAC address
+     * data values 6 - 11 encode destination MAC address
+     * data values 12 - 13 encode type of packet in payload (EtherType)
+     *
+     * Ether type values:
+     *
+     * 0x0800 IPv4
+     * 0x0806 ARP packet
+     * 0x86DD IPv6
+     * 0x8100 IEEE 802.1Q tag is present
+     *
+     **/
+
+    // will parse only IP packets
+    if (data[12] != 0x08 || data[13] != 00) {
+      printf("-- non IPv4 packet, skipping\n");
+      // printf("data[12] = %02X, data[13] = %02X\n", data[12], data[13]);
+      continue;
+    }
+
+    // unsigned char preamble[8];
+    for (int i = ETH_HEAD_SIZE; i < PAYLOADSIZE; i++) {
+      printf("packet payload (%i): %02X\n", i, data[i]);
+    }
+
+    break;
+    if (j > 3) break;
   }
   printf("--- end ---\n");
 }

--- a/10_networking_overview/parse.c
+++ b/10_networking_overview/parse.c
@@ -90,10 +90,13 @@ int main ()
 
     // fgets seems to result in strange contents of headbytes so the individual bytes are
     // read individually
+    char c;
     for (int i = 0; i < HEADSIZE; i++) {
       headbytes[i] = getc(f);
-      if (headbytes[i] == EOF) break;
     }
+    // checks if EOF was encountered after reading header
+    if (feof(f))
+      break;
     headbytes[HEADSIZE+1] = 0; // manually set NUL at end
 
     /*
@@ -104,6 +107,7 @@ int main ()
       // if ((i+i) % 4 == 0 && i != 0) printf("--\n");
     }
     */
+    
 
     time_t tim = get_long(headbytes);
     struct tm * loc_tm = localtime(&tim);
@@ -118,7 +122,7 @@ int main ()
     rec_hdr.orig_len = get_long(headbytes + 12);
 
     //    printf("ts time: %s", ctime((&tim)));
-    print_rec_hdr(rec_hdr);
+    // print_rec_hdr(rec_hdr);
     int PAYLOADSIZE = rec_hdr.incl_len;
 
     // generate summary of packet
@@ -133,11 +137,15 @@ int main ()
     // ---- parse packet payload ----
     unsigned char data[PAYLOADSIZE + 1];
     // fgets(data, PAYLOADSIZE+1, f);
-    for (int i = 0; i < PAYLOADSIZE; i++)
-      printf("%d, %d, %02X\n", PAYLOADSIZE, i, getc(f));
+    // char c;
+    for (int i = 0; i < PAYLOADSIZE; i++) {
+      c = getc(f); 
+      // printf("%d, %d, %02X\n", PAYLOADSIZE, i, getc(f));
+    }
 
-
-    
-    // break;
+    // checks if EOF was encountered after reading payload
+    if (feof(f))
+      break;
   }
+  printf("--- end ---\n");
 }

--- a/10_networking_overview/parse.c
+++ b/10_networking_overview/parse.c
@@ -66,28 +66,54 @@ int main ()
   printf("net: %lu\n", get_long(&stuff[20])); // 1 for ethernet
 
   // start a cycle of reading header + packet until EOF
-  while (1) {
-    short HEADSIZE = 128;
+  // while (1) {
+  for (int j = 0; j < 10; j++) {
+    short HEADSIZE = 16;
     unsigned char headbytes[HEADSIZE + 1]; // array needs and extra char at end for NUL
-    fgets(headbytes, HEADSIZE+1, f); // fgets reads up to N - 1 chars to make space for NUL at end
+    // fgets(headbytes, HEADSIZE+1, f); // fgets reads up to N - 1 chars to make space for NUL at end
 
+    // fgets seems to result in strange contents of headbytes so the individual bytes are
+    // read individually
+    for (int i = 0; i < HEADSIZE; i++) {
+      headbytes[i] = getc(f);
+      if (headbytes[i] == EOF) break;
+    }
+    headbytes[HEADSIZE+1] = 0; // manually set NUL at end
+
+    /*
     printf("0x%X\n", headbytes[HEADSIZE]);
     for (int i = 0; i < HEADSIZE; i++) {
       printf("head c = %02x\n", headbytes[i]);
-
-      if (i > 10) break;
+      // printf("head c = %02x\n", getc(f));
+      // if ((i+i) % 4 == 0 && i != 0) printf("--\n");
     }
-    
+    */
 
     time_t tim = get_long(headbytes);
+    struct tm * loc_tm = localtime(&tim);
     // time_t now = time(&now);
     // struct tm * loc_tm = localtime(&now);
     // printf("%lu\n", time);
-    printf("ts time: %s\n", asctime(localtime(&tim)));
+
+    printf("ts time: %s", ctime((&tim)));
     printf("ts_sec: %X\n", get_long(headbytes));
     printf("ts_usec: %lu\n", get_long(headbytes + 4));
     printf("incl_len: %lu\n", get_long(headbytes + 8));
     printf("orig_len: %lu\n", get_long(headbytes + 12));
-    break;
+    int PAYLOADSIZE = get_long(headbytes + 8) - HEADSIZE;
+
+    // generate summary of packet
+    printf("> %4d-%02d-%02d %02d:%02d:%02d ", loc_tm->tm_year + 1900,
+	   loc_tm->tm_mon + 1,
+	   loc_tm->tm_mday,
+	   loc_tm->tm_hour,
+	   loc_tm->tm_min,
+	   loc_tm->tm_sec);
+    printf("%d of bytes payload (%d read)\n", get_long(headbytes + 8), get_long(headbytes + 12));
+
+    // ---- parse packet payload ----
+    unsigned char data[PAYLOADSIZE + 1];
+    fgets(data, PAYLOADSIZE+1, f);
+    // break;
   }
 }

--- a/10_networking_overview/readme.md
+++ b/10_networking_overview/readme.md
@@ -10,7 +10,19 @@ cc `pkg-config --cflags glib-2.0` parse.c -o parse
 
 Ref: https://docs.gtk.org/glib/compiling.html
 
-References
+## References
 
 - https://wiki.wireshark.org/Development/LibpcapFileFormat
-- 
+
+## Notes
+
+- it might be useful to check the position in the file after reads and terminate execution then
+- the value of snaplen might refer to the number of bytes in capture and not packets
+
+
+## Questions
+
+- What's the significance of the 1514 value in global header?
+- Why does fgets() cause problems while getc() seems to work well?
+- What's a good way to handle the EOF while reading the file?
+- what are the high-order bits (octet) in the IP protocol header used for? (the lower order ones are 0x06)


### PR DESCRIPTION
# Objective
Write a tool to parse a PCAP file captured by Wireshark and extract the binary content received in the response to an HTTP request.

# Progress

The pcap file was fully processed but the resultant binary file does not seem to correspond to a valid jpeg file. Possible causes: 

- the binary contents of the HTTP response are not extracted/concatenated properly
- the filtering of TCP packets is too aggressive and it is discarding valid information

# Remaining work